### PR TITLE
Write values back to wolf from other sources

### DIFF
--- a/main.js
+++ b/main.js
@@ -34,7 +34,7 @@ function startAdapter(options) {
     });
 
     adapter.on('stateChange', (id, state) => {
-        if (state && !state.ack && id) {
+        if (state && !state.from.startsWith("system.adapter.wolf") && id) {
             const dp = parseInt(id.split('.').pop());
             if (datapoints[dp].rw === 'r') {
                 adapter.setState(id, ack_data[dp].value, true);


### PR DESCRIPTION
Atm we can only change values of the wolf device through the iobroker GUI.
But if we have, lets say, mqtt enabled, and subscribed to a topic (to change a values with mqtt commands), the value was changed in the iobroker GUI but not send to the wolf device. With this change, we always also update the wolf device if the change is not coming from the wolf device itself.