### PR TITLE
JS-Controller 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Read in [english](docs/en/README.md).
 Lese auf [deutsch](docs/de/README.md).
 
 ## Changelog
+### 1.3.1 [2021.08.23]
+* (eifel-tech) Corrected error: DP 149 with correct Type (Issue #30)
+* (eifel-tech) Changes for js-controller 3.3
+
 ### 1.2.1 [2020.06.20]
 * (schweigel) Corrected error: DPT_Switch in boolean mode didn't work correct
 

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "name": "wolf",
-    "version": "1.2.1",
+    "version": "1.3.1",
     "title": "wolf",
     "titleLang": {
       "en": "WOLF Heating over ISM8i",
@@ -16,6 +16,18 @@
       "zh-cn": "ISM8i上的“狼”加热"
     },
     "news": {
+      "1.3.1": {
+        "en": "Changes for js-controller 3.3",
+	    "de": "Änderungen für js-Controller 3.3",
+	    "ru": "Изменения для js-controller 3.3",
+	    "pt": "Mudanças para js-controller 3.3",
+	    "nl": "Wijzigingen voor js-controller 3.3",
+	    "fr": "Changements pour js-controller 3.3",
+	    "it": "Modifiche per js-controller 3.3",
+	    "es": "Cambios para js-controller 3.3",
+	    "pl": "Zmiany dla kontrolera js 3.3",
+	    "zh-cn": "js-controller 3.3 的变化"
+      },
       "1.2.1": {
         "en": "Corrected error: DPT_Switch in boolean mode didn't work correct",
         "de": "Behobener Fehler: DPT_Switch im Booleschen Modus funktionierte nicht richtig",

--- a/js/datapoints.json
+++ b/js/datapoints.json
@@ -5,7 +5,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "2": {
     "name": "Betriebsart",
@@ -13,7 +14,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "3": {
     "name": "Modulationsgrad  Brennerleistung",
@@ -21,7 +23,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "%"
+    "einheit": "%",
+    "commonType": "number",
+    "min": 0,
+    "max": 100
   },
   "4": {
     "name": "Kesseltemperatur",
@@ -29,7 +34,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "5": {
     "name": "Sammlertemperatur",
@@ -37,7 +45,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "6": {
     "name": "Rücklauftemperatur",
@@ -45,7 +56,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "7": {
     "name": "Warmwassertemperatur",
@@ -53,7 +67,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "8": {
     "name": "Außentemperatur",
@@ -61,7 +78,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "9": {
     "name": "Status Brenner / Flamme",
@@ -69,7 +89,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "10": {
     "name": "Status Heizkreispumpe",
@@ -77,7 +98,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "11": {
     "name": "Status Speicherladepumpe",
@@ -85,7 +107,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "12": {
     "name": "Status 3-Wege-Umschaltventil",
@@ -93,7 +116,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "13": {
     "name": "Anlagendruck",
@@ -101,7 +125,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "Pa"
+    "einheit": "Pa",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "14": {
     "name": "Störung",
@@ -109,7 +136,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "15": {
     "name": "Betriebsart",
@@ -117,7 +145,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "16": {
     "name": "Modulationsgrad / Brennerleistung",
@@ -125,7 +154,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "%"
+    "einheit": "%",
+    "commonType": "number",
+    "min": 0,
+    "max": 100
   },
   "17": {
     "name": "Kesseltemperatur",
@@ -133,7 +165,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "18": {
     "name": "Sammlertemperatur",
@@ -141,7 +176,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "19": {
     "name": "Rücklauftemperatur",
@@ -149,7 +187,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "20": {
     "name": "Warmwassertemperatur",
@@ -157,7 +198,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "21": {
     "name": "Außentemperatur",
@@ -165,7 +209,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "22": {
     "name": "Status Brenner / Flamme",
@@ -173,7 +220,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "23": {
     "name": "Status Heizkreispumpe",
@@ -181,7 +229,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "24": {
     "name": "Status Speicherladepumpe",
@@ -189,7 +238,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "25": {
     "name": "Status 3-Wege-Umschaltventil",
@@ -197,7 +247,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "26": {
     "name": "Anlagendruck",
@@ -205,7 +256,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "Pa"
+    "einheit": "Pa",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "27": {
     "name": "Störung",
@@ -213,7 +267,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "28": {
     "name": "Betriebsart",
@@ -221,7 +276,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "29": {
     "name": "Modulationsgrad / Brennerleistung",
@@ -229,7 +285,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "%"
+    "einheit": "%",
+    "commonType": "number",
+    "min": 0,
+    "max": 100
   },
   "30": {
     "name": "Kesseltemperatur",
@@ -237,7 +296,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "31": {
     "name": "Sammlertemperatur",
@@ -245,7 +307,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "32": {
     "name": "Rücklauftemperatur",
@@ -253,7 +318,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "33": {
     "name": "Warmwassertemperatur",
@@ -261,7 +329,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "34": {
     "name": "Außentemperatur",
@@ -269,7 +340,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "35": {
     "name": "Status Brenner / Flamme",
@@ -277,7 +351,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "36": {
     "name": "Status Heizkreispumpe",
@@ -285,7 +360,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "37": {
     "name": "Status Speicherladepumpe",
@@ -293,7 +369,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "38": {
     "name": "Status 3-Wege-Umschaltventil",
@@ -301,7 +378,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "39": {
     "name": "Anlagendruck",
@@ -309,7 +387,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "Pa"
+    "einheit": "Pa",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "40": {
     "name": "Störung",
@@ -317,7 +398,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "41": {
     "name": "Betriebsart",
@@ -325,7 +407,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "42": {
     "name": "Modulationsgrad / Brennerleistung",
@@ -333,7 +416,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "%"
+    "einheit": "%",
+    "commonType": "number",
+    "min": 0,
+    "max": 100
   },
   "43": {
     "name": "Kesseltemperatur",
@@ -341,7 +427,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "44": {
     "name": "Sammlertemperatur",
@@ -349,7 +438,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "45": {
     "name": "Rücklauftemperatur",
@@ -357,7 +449,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "46": {
     "name": "Warmwassertemperatur",
@@ -365,7 +460,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "47": {
     "name": "Außentemperatur",
@@ -373,7 +471,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "48": {
     "name": "Status Brenner / Flamme",
@@ -381,7 +482,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "49": {
     "name": "Status Heizkreispumpe",
@@ -389,7 +491,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "50": {
     "name": "Status Speicherladepumpe",
@@ -397,7 +500,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "51": {
     "name": "Status 3-Wege-Umschaltventil",
@@ -405,7 +509,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "52": {
     "name": "Anlagendruck",
@@ -413,7 +518,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "Pa"
+    "einheit": "Pa",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "53": {
     "name": "Störung",
@@ -421,7 +529,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "54": {
     "name": "Außentemperatur",
@@ -429,7 +538,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "55": {
     "name": "Raumtemperatur",
@@ -437,7 +549,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "56": {
     "name": "Warmwassersolltemperatur",
@@ -445,7 +560,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "57": {
     "name": "Programmwahl Heizkreis",
@@ -453,7 +571,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "58": {
     "name": "Programmwahl Warmwasser",
@@ -461,7 +580,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "59": {
     "name": "Heizkreis Zeitprogramm 1",
@@ -469,7 +589,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "60": {
     "name": "Heizkreis Zeitprogramm 2",
@@ -477,7 +598,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "61": {
     "name": "Heizkreis Zeitprogramm 3",
@@ -485,7 +607,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "62": {
     "name": "Warmwasser Zeitprogramm 1",
@@ -493,7 +616,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "63": {
     "name": "Warmwasser Zeitprogramm 2",
@@ -501,7 +625,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "64": {
     "name": "Warmwasser Zeitprogramm 3",
@@ -509,7 +634,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "65": {
     "name": "Sollwertkorrektur",
@@ -517,7 +643,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "K"
+    "einheit": "K",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "66": {
     "name": "Sparfaktor",
@@ -525,7 +654,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "K"
+    "einheit": "K",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "67": {
     "name": "Störung",
@@ -533,7 +665,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "68": {
     "name": "Raumtemperatur",
@@ -541,7 +674,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "69": {
     "name": "Warmwassersolltemperatur",
@@ -549,7 +685,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "70": {
     "name": "Programmwahl Mischer",
@@ -557,7 +696,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "71": {
     "name": "Programmwahl Warmwasser",
@@ -565,7 +705,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "72": {
     "name": "Mischer Zeitprogramm 1",
@@ -573,7 +714,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "73": {
     "name": "Mischer Zeitprogramm 2",
@@ -581,7 +723,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "74": {
     "name": "Mischer Zeitprogramm 3",
@@ -589,7 +732,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "75": {
     "name": "Warmwasser Zeitprogramm 1",
@@ -597,7 +741,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "76": {
     "name": "Warmwasser Zeitprogramm 2",
@@ -605,7 +750,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "77": {
     "name": "Warmwasser Zeitprogramm 3",
@@ -613,7 +759,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "78": {
     "name": "Sollwertkorrektur",
@@ -621,7 +768,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "K"
+    "einheit": "K",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "79": {
     "name": "Sparfaktor",
@@ -629,7 +779,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "K"
+    "einheit": "K",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "80": {
     "name": "Störung",
@@ -637,7 +790,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "81": {
     "name": "Raumtemperatur",
@@ -645,7 +799,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "82": {
     "name": "Warmwassersolltemperatur",
@@ -653,7 +810,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "83": {
     "name": "Programmwahl Mischer",
@@ -661,7 +821,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "84": {
     "name": "Programmwahl Warmwasser",
@@ -669,7 +830,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "85": {
     "name": "Mischer Zeitprogramm 1",
@@ -677,7 +839,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "86": {
     "name": "Mischer Zeitprogramm 2",
@@ -685,7 +848,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "87": {
     "name": "Mischer Zeitprogramm 3",
@@ -693,7 +857,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "88": {
     "name": "Warmwasser Zeitprogramm 1",
@@ -701,7 +866,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "89": {
     "name": "Warmwasser Zeitprogramm 2",
@@ -709,7 +875,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "90": {
     "name": "Warmwasser Zeitprogramm 3",
@@ -717,7 +884,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "91": {
     "name": "Sollwertkorrektur",
@@ -725,7 +893,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "K"
+    "einheit": "K",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "92": {
     "name": "Sparfaktor",
@@ -733,7 +904,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "K"
+    "einheit": "K",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "93": {
     "name": "Störung",
@@ -741,7 +915,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "94": {
     "name": "Raumtemperatur",
@@ -749,7 +924,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "95": {
     "name": "Warmwassersolltemperatur",
@@ -757,7 +935,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "96": {
     "name": "Programmwahl Mischer",
@@ -765,7 +946,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "97": {
     "name": "Programmwahl Warmwasser",
@@ -773,7 +955,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "98": {
     "name": "Mischer Zeitprogramm 1",
@@ -781,7 +964,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "99": {
     "name": "Mischer Zeitprogramm 2",
@@ -789,7 +973,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "100": {
     "name": "Mischer Zeitprogramm 3",
@@ -797,7 +982,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "101": {
     "name": "Warmwasser Zeitprogramm 1",
@@ -805,7 +991,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "102": {
     "name": "Warmwasser Zeitprogramm 2",
@@ -813,7 +1000,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "103": {
     "name": "Warmwasser Zeitprogramm 3",
@@ -821,7 +1009,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "104": {
     "name": "Sollwertkorrektur",
@@ -829,7 +1018,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "K"
+    "einheit": "K",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "105": {
     "name": "Sparfaktor",
@@ -837,7 +1029,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "K"
+    "einheit": "K",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "106": {
     "name": "Störung",
@@ -845,7 +1040,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "107": {
     "name": "Sammlertemperatur",
@@ -853,7 +1049,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "108": {
     "name": "Gesamtmodulationsgrad",
@@ -861,7 +1060,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "%"
+    "einheit": "%",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "109": {
     "name": "Vorlauftemperatur Mischerkreis",
@@ -869,7 +1071,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "110": {
     "name": "Status Mischerkreispumpe",
@@ -877,7 +1082,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "111": {
     "name": "Status Ausgang A1",
@@ -885,7 +1091,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "112": {
     "name": "Eingang E1",
@@ -893,7 +1100,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "113": {
     "name": "Eingang E2",
@@ -901,7 +1111,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "114": {
     "name": "Störung",
@@ -909,7 +1122,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "115": {
     "name": "Warmwassertemperatur",
@@ -917,7 +1131,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "116": {
     "name": "Vorlauftemperatur Mischerkreis",
@@ -925,7 +1142,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "117": {
     "name": "Status Mischerkreispumpe",
@@ -933,7 +1153,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "118": {
     "name": "Status Ausgang A1",
@@ -941,7 +1162,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "119": {
     "name": "Eingang E1",
@@ -949,7 +1171,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "120": {
     "name": "Eingang E2",
@@ -957,7 +1182,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "121": {
     "name": "Störung",
@@ -965,7 +1193,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "122": {
     "name": "Warmwassertemperatur",
@@ -973,7 +1202,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "123": {
     "name": "Vorlauftemperatur Mischerkreis",
@@ -981,7 +1213,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "124": {
     "name": "Status Mischerkreispumpe",
@@ -989,7 +1224,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "125": {
     "name": "Status Ausgang A1",
@@ -997,7 +1233,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "126": {
     "name": "Eingang E1",
@@ -1005,7 +1242,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "127": {
     "name": "Eingang E2",
@@ -1013,7 +1253,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "128": {
     "name": "Störung",
@@ -1021,7 +1264,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "129": {
     "name": "Warmwassertemperatur",
@@ -1029,7 +1273,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "130": {
     "name": "Vorlauftemperatur Mischerkreis",
@@ -1037,7 +1284,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "131": {
     "name": "Status Mischerkreispumpe",
@@ -1045,7 +1295,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "132": {
     "name": "Status Ausgang A1",
@@ -1053,7 +1304,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "133": {
     "name": "Eingang E1",
@@ -1061,7 +1313,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "134": {
     "name": "Eingang E2",
@@ -1069,7 +1324,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "135": {
     "name": "Störung",
@@ -1077,7 +1335,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "136": {
     "name": "Warmwassertemperatur Solar 1",
@@ -1085,7 +1344,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "137": {
     "name": "Temperatur Kollektor 1",
@@ -1093,7 +1355,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "138": {
     "name": "Eingang E1",
@@ -1101,7 +1366,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "139": {
     "name": "Eingang E2 (Durchfluss)",
@@ -1109,7 +1377,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "l/h"
+    "einheit": "l/h",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "140": {
     "name": "Eingang E3",
@@ -1117,7 +1388,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "141": {
     "name": "Status Solarkreispumpe SKP1",
@@ -1125,7 +1399,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "142": {
     "name": "Status Ausgang A1",
@@ -1133,7 +1408,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "143": {
     "name": "Status Ausgang A2",
@@ -1141,7 +1417,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "144": {
     "name": "Status Ausgang A3",
@@ -1149,7 +1426,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "145": {
     "name": "Status Ausgang A4",
@@ -1157,7 +1435,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "146": {
     "name": "Durchfluss",
@@ -1165,7 +1444,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "l/h"
+    "einheit": "l/h",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "147": {
     "name": "aktuelle Leistung",
@@ -1173,7 +1455,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "kW"
+    "einheit": "kW",
+    "commonType": "number",
+    "min": 0,
+    "max": 10000
   },
   "148": {
     "name": "Störung",
@@ -1181,15 +1466,17 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "149": {
     "name": "Programmwahl CWL",
-    "type": "DPT_DHWMode",
+    "type": "DPT_HVACMode",
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "150": {
     "name": "Zeitprogramm 1",
@@ -1197,7 +1484,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "151": {
     "name": "Zeitprogramm 2",
@@ -1205,7 +1493,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "152": {
     "name": "Zeitprogramm 3",
@@ -1213,7 +1502,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "153": {
     "name": "Zeitweise Intensivlüftung AN/AUS",
@@ -1221,7 +1511,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "154": {
     "name": "Zeitweise Intensivlüftung Startdatum",
@@ -1229,7 +1520,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "155": {
     "name": "Zeitweise Intensivlüftung Enddatum",
@@ -1237,7 +1529,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "156": {
     "name": "Zeitweise Intensivlüftung Startzeit",
@@ -1245,7 +1538,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "157": {
     "name": "Zeitweise Intensivlüftung Endzeit",
@@ -1253,7 +1547,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "158": {
     "name": "Zeitweiser Feuchteschutz AN/AUS",
@@ -1261,7 +1556,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "159": {
     "name": "Zeitweiser Feuchteschutz Startdatum",
@@ -1269,7 +1565,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "160": {
     "name": "Zeitweiser Feuchteschutz Enddatum",
@@ -1277,7 +1574,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "161": {
     "name": "Zeitweiser Feuchteschutz Startzeit",
@@ -1285,7 +1583,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "162": {
     "name": "Zeitweiser Feuchteschutz Endzeit",
@@ -1293,7 +1592,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "163": {
     "name": "Lüftungsstufe",
@@ -1301,7 +1601,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "%"
+    "einheit": "%",
+    "commonType": "number",
+    "min": 0,
+    "max": 100
   },
   "164": {
     "name": "Ablufttemperatur",
@@ -1309,7 +1612,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "165": {
     "name": "Frischlufttemperatur",
@@ -1317,7 +1623,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "166": {
     "name": "Luftdurchsatz Zuluft",
@@ -1325,7 +1634,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "m³/h"
+    "einheit": "m³/h",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "167": {
     "name": "Luftdurchsatz Abluft",
@@ -1333,7 +1645,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "m³/h"
+    "einheit": "m³/h",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "168": {
     "name": "Bypass Initialisierung",
@@ -1341,7 +1656,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "169": {
     "name": "Bypass öffnet/offen",
@@ -1349,7 +1665,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "170": {
     "name": "Bypass schließt/geschlossen",
@@ -1357,7 +1674,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "171": {
     "name": "Bypass Fehler",
@@ -1365,7 +1683,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "172": {
     "name": "Frost Status: Initialisierung/Warte",
@@ -1373,7 +1692,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "173": {
     "name": "Frost Status: Kein Frost",
@@ -1381,7 +1701,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "174": {
     "name": "Frost Status: Vorwärmer",
@@ -1389,7 +1710,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "175": {
     "name": "Frost Status: Fehler/Unausgeglichen",
@@ -1397,7 +1719,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "176": {
     "name": "Störung",
@@ -1405,7 +1728,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "177": {
     "name": "Betriebsart",
@@ -1413,7 +1737,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "178": {
     "name": "Heizleistung",
@@ -1421,7 +1746,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "kW"
+    "einheit": "kW",
+    "commonType": "number",
+    "min": 0,
+    "max": 10000
   },
   "179": {
     "name": "Kühlleistung",
@@ -1429,7 +1757,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "kW"
+    "einheit": "kW",
+    "commonType": "number",
+    "min": 0,
+    "max": 10000
   },
   "180": {
     "name": "Kesseltemperatur",
@@ -1437,7 +1768,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "181": {
     "name": "Sammlertemperatur",
@@ -1445,7 +1779,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "182": {
     "name": "Rücklauftemperatur",
@@ -1453,7 +1790,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "183": {
     "name": "Warmwassertemperatur",
@@ -1461,7 +1801,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "184": {
     "name": "Außentemperatur",
@@ -1469,7 +1812,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "185": {
     "name": "Status Heizkreispumpe",
@@ -1477,7 +1823,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "186": {
     "name": "Status Zubringer-/Heizkreispumpe",
@@ -1485,7 +1832,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "187": {
     "name": "Status 3-Wege-Umschaltventil HZ/WW",
@@ -1493,7 +1841,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "188": {
     "name": "Status 3-Wege-Umschaltventil HZ/K",
@@ -1501,7 +1850,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "189": {
     "name": "Status E-Heizung",
@@ -1509,7 +1859,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "190": {
     "name": "Anlagendruck",
@@ -1517,7 +1868,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "Pa"
+    "einheit": "Pa",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "191": {
     "name": "Leistungsaufnahme",
@@ -1525,7 +1879,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "kW"
+    "einheit": "kW",
+    "commonType": "number",
+    "min": 0,
+    "max": 10000
   },
   "192": {
     "name": "Filterwarnung aktiv",
@@ -1533,7 +1890,8 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "193": {
     "name": "Filerwarnung zurücksetzen",
@@ -1541,7 +1899,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "194": {
     "name": "1x Warmwasserladung (global)",
@@ -1549,7 +1908,8 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": ""
+    "einheit": "",
+    "commonType": "string"
   },
   "195": {
     "name": "Tagesertrag",
@@ -1557,7 +1917,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "Wh"
+    "einheit": "Wh",
+    "commonType": "number",
+    "min": 0,
+    "max": 10000
   },
   "196": {
     "name": "Gesamtertrag",
@@ -1565,7 +1928,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "kWh"
+    "einheit": "kWh",
+    "commonType": "number",
+    "min": 0,
+    "max": 100000
   },
   "197": {
     "name": "Abgastemperatur",
@@ -1573,7 +1939,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "198": {
     "name": "Leistungsvorgabe",
@@ -1581,7 +1950,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "%"
+    "einheit": "%",
+    "commonType": "number",
+    "min": 0,
+    "max": 100
   },
   "199": {
     "name": "Kesselsolltemperaturvorgabe",
@@ -1589,7 +1961,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "200": {
     "name": "Abgastemperatur",
@@ -1597,7 +1972,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "201": {
     "name": "Leistungsvorgabe",
@@ -1605,7 +1983,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "%"
+    "einheit": "%",
+    "commonType": "number",
+    "min": 0,
+    "max": 100
   },
   "202": {
     "name": "Kesselsolltemperaturvorgabe",
@@ -1613,7 +1994,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "203": {
     "name": "Abgastemperatur",
@@ -1621,7 +2005,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "204": {
     "name": "Leistungsvorgabe",
@@ -1629,7 +2016,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "%"
+    "einheit": "%",
+    "commonType": "number",
+    "min": 0,
+    "max": 100
   },
   "205": {
     "name": "Kesselsolltemperaturvorgabe",
@@ -1637,7 +2027,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "206": {
     "name": "Abgastemperatur",
@@ -1645,7 +2038,10 @@
     "rw": "r",
     "read": true,
     "write": false,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "207": {
     "name": "Leistungsvorgabe",
@@ -1653,7 +2049,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "%"
+    "einheit": "%",
+    "commonType": "number",
+    "min": 0,
+    "max": 100
   },
   "208": {
     "name": "Kesselsolltemperaturvorgabe",
@@ -1661,7 +2060,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   },
   "209": {
     "name": "Gesamtmodulationsgradvorgabe",
@@ -1669,7 +2071,10 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "%"
+    "einheit": "%",
+    "commonType": "number",
+    "min": 0,
+    "max": 100
   },
   "210": {
     "name": "Sammlersolltemperaturvorgabe",
@@ -1677,6 +2082,9 @@
     "rw": "rw",
     "read": true,
     "write": true,
-    "einheit": "°C"
+    "einheit": "°C",
+    "commonType": "number",
+    "min": 0,
+    "max": 1000
   } 
 }

--- a/js/datapoints.json
+++ b/js/datapoints.json
@@ -128,7 +128,7 @@
     "einheit": "Pa",
     "commonType": "number",
     "min": 0,
-    "max": 1000
+    "max": 1000000
   },
   "14": {
     "name": "Störung",

--- a/js/datapoints.json
+++ b/js/datapoints.json
@@ -26,7 +26,7 @@
     "einheit": "%",
     "commonType": "number",
     "min": 0,
-    "max": 100
+    "max": 1000
   },
   "4": {
     "name": "Kesseltemperatur",
@@ -157,7 +157,7 @@
     "einheit": "%",
     "commonType": "number",
     "min": 0,
-    "max": 100
+    "max": 1000
   },
   "17": {
     "name": "Kesseltemperatur",
@@ -288,7 +288,7 @@
     "einheit": "%",
     "commonType": "number",
     "min": 0,
-    "max": 100
+    "max": 1000
   },
   "30": {
     "name": "Kesseltemperatur",
@@ -419,7 +419,7 @@
     "einheit": "%",
     "commonType": "number",
     "min": 0,
-    "max": 100
+    "max": 1000
   },
   "43": {
     "name": "Kesseltemperatur",
@@ -1604,7 +1604,7 @@
     "einheit": "%",
     "commonType": "number",
     "min": 0,
-    "max": 100
+    "max": 1000
   },
   "164": {
     "name": "Ablufttemperatur",
@@ -1953,7 +1953,7 @@
     "einheit": "%",
     "commonType": "number",
     "min": 0,
-    "max": 100
+    "max": 1000
   },
   "199": {
     "name": "Kesselsolltemperaturvorgabe",
@@ -1986,7 +1986,7 @@
     "einheit": "%",
     "commonType": "number",
     "min": 0,
-    "max": 100
+    "max": 1000
   },
   "202": {
     "name": "Kesselsolltemperaturvorgabe",
@@ -2019,7 +2019,7 @@
     "einheit": "%",
     "commonType": "number",
     "min": 0,
-    "max": 100
+    "max": 1000
   },
   "205": {
     "name": "Kesselsolltemperaturvorgabe",
@@ -2052,7 +2052,7 @@
     "einheit": "%",
     "commonType": "number",
     "min": 0,
-    "max": 100
+    "max": 1000
   },
   "208": {
     "name": "Kesselsolltemperaturvorgabe",
@@ -2074,7 +2074,7 @@
     "einheit": "%",
     "commonType": "number",
     "min": 0,
-    "max": 100
+    "max": 1000
   },
   "210": {
     "name": "Sammlersolltemperaturvorgabe",

--- a/js/datapoints.json
+++ b/js/datapoints.json
@@ -259,7 +259,7 @@
     "einheit": "Pa",
     "commonType": "number",
     "min": 0,
-    "max": 1000
+    "max": 1000000
   },
   "27": {
     "name": "Störung",
@@ -390,7 +390,7 @@
     "einheit": "Pa",
     "commonType": "number",
     "min": 0,
-    "max": 1000
+    "max": 1000000
   },
   "40": {
     "name": "Störung",
@@ -521,7 +521,7 @@
     "einheit": "Pa",
     "commonType": "number",
     "min": 0,
-    "max": 1000
+    "max": 1000000
   },
   "53": {
     "name": "Störung",
@@ -1871,7 +1871,7 @@
     "einheit": "Pa",
     "commonType": "number",
     "min": 0,
-    "max": 1000
+    "max": 1000000
   },
   "191": {
     "name": "Leistungsaufnahme",

--- a/main.js
+++ b/main.js
@@ -467,21 +467,41 @@ function addDevice(dp, callback) {
                 }
                 ack_data[range.lsb] = {id: adapter.namespace + '.' + dev + '.' + range.lsb};
                 //console.log('add:' + dev + '.' + range.lsb  );
-                adapter.setObject(dev + '.' + range.lsb, {
-                    type: 'state',
-                    common: {
-                        name: data.name,
-                        role: data.type.replace('DPT_', ''),
-                        type: 'state',
-                        read: data.read,
-                        write: data.write,
-                        unit: data.einheit,
-                        enabled: false
-                    },
-                    native: {
-                        rw: data.rw
-                    }
-                });
+                if(data.commonType === 'number') {
+                	adapter.setObject(dev + '.' + range.lsb, {
+	                    type: 'state',
+	                    common: {
+	                        name: data.name,
+	                        role: data.type.replace('DPT_', ''),
+	                        type: data.commonType,
+	                        read: data.read,
+	                        write: data.write,
+	                        unit: data.einheit,
+	                        min: data.min,
+	                        max: data.max,
+	                        enabled: false
+	                    },
+	                    native: {
+	                        rw: data.rw
+	                    }
+	                });
+                } else {
+	                adapter.setObject(dev + '.' + range.lsb, {
+	                    type: 'state',
+	                    common: {
+	                        name: data.name,
+	                        role: data.type.replace('DPT_', ''),
+	                        type: data.commonType,
+	                        read: data.read,
+	                        write: data.write,
+	                        unit: data.einheit,
+	                        enabled: false
+	                    },
+	                    native: {
+	                        rw: data.rw
+	                    }
+	                });
+                }
             }
         }
 
@@ -496,21 +516,41 @@ function addDevice(dp, callback) {
                     }
                     ack_data[range.lsb2] = {id: adapter.namespace + '.' + dev + '.' + range.lsb2};
                     //console.log('add:' + dev + '.' + range.lsb2  );
-                    adapter.setObject(dev + '.' + range.lsb2, {
-                        type: 'state',
-                        common: {
-                            name: data.name,
-                            role: data.type.replace('DPT_', ''),
-                            type: 'state',
-                            read: data.read,
-                            write: data.write,
-                            unit: data.einheit,
-                            enabled: false,
-                        },
-                        native: {
-                            rw: data.rw
-                        }
-                    });
+                    if(data.commonType === 'number') {
+	                	adapter.setObject(dev + '.' + range.lsb2, {
+		                    type: 'state',
+		                    common: {
+		                        name: data.name,
+		                        role: data.type.replace('DPT_', ''),
+		                        type: data.commonType,
+		                        read: data.read,
+		                        write: data.write,
+		                        unit: data.einheit,
+		                        min: data.min,
+		                        max: data.max,
+		                        enabled: false
+		                    },
+		                    native: {
+		                        rw: data.rw
+		                    }
+		                });
+	                } else {
+	                    adapter.setObject(dev + '.' + range.lsb2, {
+	                        type: 'state',
+	                        common: {
+	                            name: data.name,
+	                            role: data.type.replace('DPT_', ''),
+	                            type: data.commonType,
+	                            read: data.read,
+	                            write: data.write,
+	                            unit: data.einheit,
+	                            enabled: false,
+	                        },
+	                        native: {
+	                            rw: data.rw
+	                        }
+	                    });
+	                }
                 }
             }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.wolf",
-  "version": "1.2.1",
+  "version": "1.3.1",
   "description": "Wolf Heating over ISM8i",
   "author": {
     "name": "smiling_Jack",


### PR DESCRIPTION
The original adapter creates objects always with type `state`. But they have to be `string`, `number ` and so on. With js-controller 3.3 this is checked. With these changes the adapter should be ready for actual js-controller.